### PR TITLE
Disable next-pwa during production builds

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,8 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
 })
 
 const withPWA = require("next-pwa")({
-  dest: "public"
+  dest: "public",
+  disable: process.env.NODE_ENV === "production"
 })
 
 module.exports = withBundleAnalyzer(


### PR DESCRIPTION
## Summary
- disable next-pwa plugin when `NODE_ENV` is `production` to avoid incompatibility with Next.js 14

## Testing
- `npm test` *(fails: extractOpenapiData expects property 'stocksTicker'; Playwright tests misconfigured)*
- `npm run build` *(fails: unable to fetch Google Font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68960e922a98832c8d5bfc27a5280233